### PR TITLE
Setting for only one service being `AlwaysConnected`

### DIFF
--- a/Common/ACPreferences.h
+++ b/Common/ACPreferences.h
@@ -61,6 +61,13 @@ extern NSString * const kACMenuBarImageDidChange;
 
 
 /**
+ Enable auto connecting to max one service.
+ */
+-(BOOL)singleAutoConnect;
+-(void)setSingleAutoConnect:(BOOL)inValue;
+
+
+/**
  Menu Bar Images
  */
 

--- a/Common/ACPreferences.m
+++ b/Common/ACPreferences.m
@@ -82,7 +82,7 @@ NSString * const kACMenuBarImageDidChange = @"kACMenuBarImageDidChange";
 
 			serviceFound = YES;
 		}
-		else if([self singleAutoConnect])
+		else if(inAlwaysConnected && [self singleAutoConnect])
 		{
 			NSMutableDictionary *updatedServiceDictionary = [service mutableCopy];
 			updatedServiceDictionary[kServiceAlwaysConnectedKey] = [NSNumber numberWithBool:false];

--- a/Common/ACPreferences.m
+++ b/Common/ACPreferences.m
@@ -81,14 +81,15 @@ NSString * const kACMenuBarImageDidChange = @"kACMenuBarImageDidChange";
 			[services addObject:updatedServiceDictionary];
 
 			serviceFound = YES;
-    } else if([self singleAutoConnect])
-    {
-      NSMutableDictionary *updatedServiceDictionary = [service mutableCopy];
-      updatedServiceDictionary[kServiceAlwaysConnectedKey] = [NSNumber numberWithBool:false];
+		}
+		else if([self singleAutoConnect])
+		{
+			NSMutableDictionary *updatedServiceDictionary = [service mutableCopy];
+			updatedServiceDictionary[kServiceAlwaysConnectedKey] = [NSNumber numberWithBool:false];
 
-      [services removeObject:service];
-      [services addObject:updatedServiceDictionary];
-    }
+			[services removeObject:service];
+			[services addObject:updatedServiceDictionary];
+		}
 	}
 
 	if(!serviceFound)
@@ -211,12 +212,12 @@ NSString * const kACMenuBarImageDidChange = @"kACMenuBarImageDidChange";
 
 -(BOOL)singleAutoConnect
 {
-  return [[NSUserDefaults standardUserDefaults] boolForKey:kSingleAutoConnectPrefKey];
+	return [[NSUserDefaults standardUserDefaults] boolForKey:kSingleAutoConnectPrefKey];
 }
 
 -(void)setSingleAutoConnect:(BOOL)inValue
 {
-  [[NSUserDefaults standardUserDefaults] setBool:inValue forKey:kSingleAutoConnectPrefKey];
+	[[NSUserDefaults standardUserDefaults] setBool:inValue forKey:kSingleAutoConnectPrefKey];
 }
 
 -(MenuBarImageType)menuBarImageType

--- a/Common/ACPreferences.m
+++ b/Common/ACPreferences.m
@@ -81,8 +81,14 @@ NSString * const kACMenuBarImageDidChange = @"kACMenuBarImageDidChange";
 			[services addObject:updatedServiceDictionary];
 
 			serviceFound = YES;
-			break;
-		}
+    } else if([self singleAutoConnect])
+    {
+      NSMutableDictionary *updatedServiceDictionary = [service mutableCopy];
+      updatedServiceDictionary[kServiceAlwaysConnectedKey] = [NSNumber numberWithBool:false];
+
+      [services removeObject:service];
+      [services addObject:updatedServiceDictionary];
+    }
 	}
 
 	if(!serviceFound)

--- a/Common/ACPreferences.m
+++ b/Common/ACPreferences.m
@@ -69,7 +69,8 @@ NSString * const kACMenuBarImageDidChange = @"kACMenuBarImageDidChange";
 		services = [[NSMutableArray alloc] init];
 	}
 
-	for(NSDictionary *service in services)
+	// Use a copy to avoid looping through an array that is being modified during the loop
+	for(NSDictionary *service in [services copy])
 	{
 		NSString *serviceIdentifier = service[kServiceIdentifierKey];
 		if([serviceIdentifier isEqualToString:inServiceIdentifier])

--- a/Common/ACPreferences.m
+++ b/Common/ACPreferences.m
@@ -20,6 +20,7 @@ NSString * const kServiceIgnoredVPNsKey = @"IgnoredVPNs";
 NSString * const kAlwaysConnectedRetryDelayPrefKey = @"AlwaysConnectedRetryDelay";
 
 NSString * const kDisabledCheckForUpdatesAutomaticallyPrefKey = @"DisabledCheckForUpdatesAutomatically";
+NSString * const kSingleAutoConnectPrefKey = @"SingleAutoConnect";
 NSString * const kMenuBarImageTypePrefKey = @"MenuBarImageType";
 
 NSString * const kACConfigurationDidChange = @"kACConfigurationDidChange";
@@ -200,6 +201,16 @@ NSString * const kACMenuBarImageDidChange = @"kACMenuBarImageDidChange";
 -(void)setDisabledCheckForUpdatesAutomatically:(BOOL)inValue
 {
 	[[NSUserDefaults standardUserDefaults] setBool:inValue forKey:kDisabledCheckForUpdatesAutomaticallyPrefKey];
+}
+
+-(BOOL)singleAutoConnect
+{
+  return [[NSUserDefaults standardUserDefaults] boolForKey:kSingleAutoConnectPrefKey];
+}
+
+-(void)setSingleAutoConnect:(BOOL)inValue
+{
+  [[NSUserDefaults standardUserDefaults] setBool:inValue forKey:kSingleAutoConnectPrefKey];
 }
 
 -(MenuBarImageType)menuBarImageType

--- a/VPNStatus/Base.lproj/ACCrossPromotionWindow.xib
+++ b/VPNStatus/Base.lproj/ACCrossPromotionWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
         <window title="From the same developer" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" tabbingMode="disallowed" id="xOd-HO-29H" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="133" y="235" width="471" height="303"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1710" height="1069"/>
             <value key="minSize" type="size" width="471" height="303"/>
             <value key="maxSize" type="size" width="471" height="303"/>
             <value key="minFullScreenContentSize" type="size" width="471" height="303"/>
@@ -62,7 +62,7 @@
                                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="3" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pNf-j0-tGB">
                                         <rect key="frame" x="82" y="22" width="150" height="33"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zeg-Ha-1do">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zeg-Ha-1do">
                                                 <rect key="frame" x="-2" y="17" width="73" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="MarkChart" id="yQk-ZW-ZYH">
                                                     <font key="font" textStyle="headline" name=".SFNS-Bold"/>
@@ -70,7 +70,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OK1-bJ-hmH">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OK1-bJ-hmH">
                                                 <rect key="frame" x="-2" y="0.0" width="146" height="14"/>
                                                 <textFieldCell key="cell" title="Preview Mermaid diagrams" id="6iB-aD-z2o">
                                                     <font key="font" textStyle="subheadline" name=".SFNS-Regular"/>
@@ -146,7 +146,7 @@
                                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="3" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VC1-Ul-sCi">
                                         <rect key="frame" x="82" y="22" width="150" height="33"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ekS-uP-1kK">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ekS-uP-1kK">
                                                 <rect key="frame" x="-2" y="17" width="96" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Dependencies" id="upD-tw-8po">
                                                     <font key="font" textStyle="headline" name=".SFNS-Bold"/>
@@ -154,7 +154,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K6P-fm-abg">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K6P-fm-abg">
                                                 <rect key="frame" x="-2" y="0.0" width="95" height="14"/>
                                                 <textFieldCell key="cell" title="Analyze your app" id="Ed8-7V-oc8">
                                                     <font key="font" textStyle="subheadline" name=".SFNS-Regular"/>
@@ -230,7 +230,7 @@
                                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="3" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n5d-8b-0PC">
                                         <rect key="frame" x="82" y="22" width="150" height="33"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ie8-la-hfc">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ie8-la-hfc">
                                                 <rect key="frame" x="-2" y="17" width="75" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="VPNStatus" id="gbX-YX-ycX">
                                                     <font key="font" textStyle="headline" name=".SFNS-Bold"/>
@@ -238,7 +238,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cCl-MV-z0B">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cCl-MV-z0B">
                                                 <rect key="frame" x="-2" y="0.0" width="123" height="14"/>
                                                 <textFieldCell key="cell" title="Auto connect to a VPN" id="Vr0-nT-DxM">
                                                     <font key="font" textStyle="subheadline" name=".SFNS-Regular"/>

--- a/VPNStatus/Base.lproj/ACPreferencesAboutView.xib
+++ b/VPNStatus/Base.lproj/ACPreferencesAboutView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,7 +27,7 @@
                     </constraints>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon" id="5NO-xE-yFC"/>
                 </imageView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K3Q-df-0o3">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K3Q-df-0o3">
                     <rect key="frame" x="261" y="209" width="79" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="VPNStatus" id="c4R-ke-SFN">
                         <font key="font" metaFont="systemBold"/>
@@ -35,7 +35,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dkf-TQ-yQo">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dkf-TQ-yQo">
                     <rect key="frame" x="276" y="187" width="48" height="14"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Version" id="fsO-os-8rb">
                         <font key="font" metaFont="smallSystem"/>
@@ -43,7 +43,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yL7-wI-Gad">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yL7-wI-Gad">
                     <rect key="frame" x="215" y="153" width="171" height="14"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Copyright © Alexandre Colucci" id="10m-WU-1rH">
                         <font key="font" metaFont="smallSystem"/>

--- a/VPNStatus/Base.lproj/ACPreferencesGeneralView.xib
+++ b/VPNStatus/Base.lproj/ACPreferencesGeneralView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23094" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23094"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -11,6 +11,7 @@
                 <outlet property="automaticCheckForUpdatesButton" destination="dKe-mY-Q8g" id="deo-tr-Dk5"/>
                 <outlet property="menuBarImagePopUpButton" destination="JEm-iV-Zdi" id="10I-hd-DLI"/>
                 <outlet property="retryDelayField" destination="q5O-D3-mgT" id="P6H-Qj-cWL"/>
+                <outlet property="singleAutoConnectButton" destination="YCL-cX-bWo" id="v3T-Gb-KY0"/>
                 <outlet property="view" destination="6sE-tW-1JD" id="Fk7-dv-Doh"/>
             </connections>
         </customObject>
@@ -20,15 +21,15 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="317"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K3Q-df-0o3">
-                    <rect key="frame" x="106" y="175" width="78" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="K3Q-df-0o3">
+                    <rect key="frame" x="106" y="200" width="78" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Retry Delay:" id="c4R-ke-SFN">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6QB-Sz-gYR">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6QB-Sz-gYR">
                     <rect key="frame" x="78" y="261" width="106" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Menu Bar Image:" id="hfn-1y-57L">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -36,8 +37,8 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="q5O-D3-mgT">
-                    <rect key="frame" x="190" y="173" width="60" height="21"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q5O-D3-mgT">
+                    <rect key="frame" x="190" y="198" width="60" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="60" id="YvO-Ic-mF5"/>
                     </constraints>
@@ -54,16 +55,16 @@
                         <action selector="retryDelayDidChange:" target="-2" id="BKx-p4-cUL"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="59l-qm-2nr">
-                    <rect key="frame" x="252" y="175" width="11" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="59l-qm-2nr">
+                    <rect key="frame" x="252" y="205" width="11" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="s" id="aVA-4k-mIU">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dkf-TQ-yQo">
-                    <rect key="frame" x="188" y="151" width="335" height="14"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dkf-TQ-yQo">
+                    <rect key="frame" x="188" y="176" width="335" height="14"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="VPNStatus tries to reconnect to the VPN every 120s by default." id="fsO-os-8rb">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -90,7 +91,7 @@
                         <action selector="doCheckForUpdates:" target="-2" id="FVR-SJ-4dV"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O7D-qa-qEI">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O7D-qa-qEI">
                     <rect key="frame" x="125" y="89" width="59" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Updates:" id="aic-J6-s0i">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -98,6 +99,16 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YCL-cX-bWo">
+                    <rect key="frame" x="188" y="133" width="171" height="18"/>
+                    <buttonCell key="cell" type="check" title="Restrict to one at a time" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="x0v-Tf-hbq">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="doSingleAutoConnect:" target="-2" id="OJ5-wz-EvE"/>
+                    </connections>
+                </button>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JEm-iV-Zdi">
                     <rect key="frame" x="187" y="254" width="157" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Colors" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="FgX-Y2-4gP" id="GzK-wy-lNk">
@@ -117,8 +128,17 @@
                         <action selector="doChangeMenuBarImage:" target="-2" id="yqg-7q-4Au"/>
                     </connections>
                 </popUpButton>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CHj-7i-3Ej">
+                    <rect key="frame" x="95" y="134" width="89" height="16"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="Auto connect:" id="cKR-Jw-249">
+                        <font key="font" usesAppearanceFont="YES"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
+                <constraint firstItem="CHj-7i-3Ej" firstAttribute="centerY" secondItem="YCL-cX-bWo" secondAttribute="centerY" id="2Ox-8t-wmU"/>
                 <constraint firstItem="6QB-Sz-gYR" firstAttribute="firstBaseline" secondItem="JEm-iV-Zdi" secondAttribute="firstBaseline" id="2jO-19-zwA"/>
                 <constraint firstItem="6QB-Sz-gYR" firstAttribute="top" secondItem="6sE-tW-1JD" secondAttribute="top" constant="40" id="2vq-EA-a2N"/>
                 <constraint firstItem="q5O-D3-mgT" firstAttribute="centerY" secondItem="59l-qm-2nr" secondAttribute="centerY" id="4nV-aY-Z6G"/>
@@ -138,6 +158,7 @@
                 <constraint firstItem="K3Q-df-0o3" firstAttribute="top" secondItem="6QB-Sz-gYR" secondAttribute="bottom" constant="70" id="bNp-I2-jUP"/>
                 <constraint firstItem="1xo-AV-r9d" firstAttribute="top" secondItem="dKe-mY-Q8g" secondAttribute="bottom" constant="14" id="cxa-w5-zHt"/>
                 <constraint firstItem="K3Q-df-0o3" firstAttribute="trailing" secondItem="6QB-Sz-gYR" secondAttribute="trailing" id="fw3-r6-EOz"/>
+                <constraint firstItem="YCL-cX-bWo" firstAttribute="leading" secondItem="CHj-7i-3Ej" secondAttribute="trailing" constant="8" symbolic="YES" id="jJN-vH-1KW"/>
                 <constraint firstItem="K3Q-df-0o3" firstAttribute="centerY" secondItem="q5O-D3-mgT" secondAttribute="centerY" id="mYj-NO-QFZ"/>
                 <constraint firstItem="Dkf-TQ-yQo" firstAttribute="leading" secondItem="q5O-D3-mgT" secondAttribute="leading" id="nqg-E8-90a"/>
                 <constraint firstItem="O7D-qa-qEI" firstAttribute="centerY" secondItem="dKe-mY-Q8g" secondAttribute="centerY" id="p8G-Ef-ywH"/>

--- a/VPNStatus/Base.lproj/ACPreferencesGeneralView.xib
+++ b/VPNStatus/Base.lproj/ACPreferencesGeneralView.xib
@@ -21,8 +21,8 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="317"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="K3Q-df-0o3">
-                    <rect key="frame" x="106" y="200" width="78" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K3Q-df-0o3">
+                    <rect key="frame" x="106" y="195" width="78" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Retry Delay:" id="c4R-ke-SFN">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -37,8 +37,8 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q5O-D3-mgT">
-                    <rect key="frame" x="190" y="198" width="60" height="21"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="q5O-D3-mgT">
+                    <rect key="frame" x="190" y="193" width="60" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="60" id="YvO-Ic-mF5"/>
                     </constraints>
@@ -55,16 +55,16 @@
                         <action selector="retryDelayDidChange:" target="-2" id="BKx-p4-cUL"/>
                     </connections>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="59l-qm-2nr">
-                    <rect key="frame" x="252" y="205" width="11" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="59l-qm-2nr">
+                    <rect key="frame" x="252" y="195" width="11" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="s" id="aVA-4k-mIU">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dkf-TQ-yQo">
-                    <rect key="frame" x="188" y="176" width="335" height="14"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dkf-TQ-yQo">
+                    <rect key="frame" x="188" y="171" width="335" height="14"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="VPNStatus tries to reconnect to the VPN every 120s by default." id="fsO-os-8rb">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -72,7 +72,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dKe-mY-Q8g">
-                    <rect key="frame" x="188" y="88" width="222" height="18"/>
+                    <rect key="frame" x="188" y="87" width="222" height="18"/>
                     <buttonCell key="cell" type="check" title="Check for updates automatically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="yIg-zg-E6G">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -82,7 +82,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1xo-AV-r9d">
-                    <rect key="frame" x="183" y="48" width="178" height="32"/>
+                    <rect key="frame" x="183" y="47" width="178" height="32"/>
                     <buttonCell key="cell" type="push" title="Check for Updates Now" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="udO-5A-Apk">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -92,15 +92,15 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O7D-qa-qEI">
-                    <rect key="frame" x="125" y="89" width="59" height="16"/>
+                    <rect key="frame" x="125" y="88" width="59" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Updates:" id="aic-J6-s0i">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YCL-cX-bWo">
-                    <rect key="frame" x="188" y="133" width="171" height="18"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YCL-cX-bWo">
+                    <rect key="frame" x="188" y="128" width="171" height="18"/>
                     <buttonCell key="cell" type="check" title="Restrict to one at a time" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="x0v-Tf-hbq">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -113,7 +113,7 @@
                     <rect key="frame" x="187" y="254" width="157" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Colors" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="FgX-Y2-4gP" id="GzK-wy-lNk">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="cvu-Ff-OwY">
                             <items>
                                 <menuItem title="Colors" state="on" image="VPNStatusItemOnImage" id="FgX-Y2-4gP"/>
@@ -122,14 +122,14 @@
                         </menu>
                     </popUpButtonCell>
                     <constraints>
-                        <constraint firstAttribute="width" constant="150" id="afK-hZ-5fG"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="afK-hZ-5fG"/>
                     </constraints>
                     <connections>
                         <action selector="doChangeMenuBarImage:" target="-2" id="yqg-7q-4Au"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CHj-7i-3Ej">
-                    <rect key="frame" x="95" y="134" width="89" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CHj-7i-3Ej">
+                    <rect key="frame" x="95" y="129" width="89" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Auto connect:" id="cKR-Jw-249">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -148,28 +148,33 @@
                 <constraint firstItem="K3Q-df-0o3" firstAttribute="trailing" secondItem="O7D-qa-qEI" secondAttribute="trailing" id="FHq-T2-2CU"/>
                 <constraint firstItem="Dkf-TQ-yQo" firstAttribute="top" secondItem="q5O-D3-mgT" secondAttribute="bottom" constant="8" symbolic="YES" id="HAq-0A-OY2"/>
                 <constraint firstItem="59l-qm-2nr" firstAttribute="leading" secondItem="q5O-D3-mgT" secondAttribute="trailing" constant="4" id="HDk-iS-M7S"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YCL-cX-bWo" secondAttribute="trailing" constant="20" symbolic="YES" id="HvJ-B1-ifo"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1xo-AV-r9d" secondAttribute="trailing" id="IOW-oA-Msu"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dKe-mY-Q8g" secondAttribute="trailing" id="Kh4-bz-Nwi"/>
                 <constraint firstItem="dKe-mY-Q8g" firstAttribute="leading" secondItem="O7D-qa-qEI" secondAttribute="trailing" constant="8" symbolic="YES" id="L7t-Mp-Nsn"/>
-                <constraint firstItem="O7D-qa-qEI" firstAttribute="top" secondItem="K3Q-df-0o3" secondAttribute="bottom" constant="70" id="PGI-Y4-5ea"/>
+                <constraint firstItem="K3Q-df-0o3" firstAttribute="leading" secondItem="6sE-tW-1JD" secondAttribute="leading" constant="108" id="PaS-Sx-ghG"/>
+                <constraint firstItem="K3Q-df-0o3" firstAttribute="trailing" secondItem="CHj-7i-3Ej" secondAttribute="trailing" id="V9K-0H-nZ8"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="59l-qm-2nr" secondAttribute="trailing" id="WNE-Vz-Bjk"/>
                 <constraint firstItem="O7D-qa-qEI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6sE-tW-1JD" secondAttribute="leading" id="WP2-fT-HQJ"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JEm-iV-Zdi" secondAttribute="trailing" id="Zto-bO-jTG"/>
-                <constraint firstItem="K3Q-df-0o3" firstAttribute="top" secondItem="6QB-Sz-gYR" secondAttribute="bottom" constant="70" id="bNp-I2-jUP"/>
+                <constraint firstItem="K3Q-df-0o3" firstAttribute="top" secondItem="6QB-Sz-gYR" secondAttribute="bottom" constant="50" id="bNp-I2-jUP"/>
                 <constraint firstItem="1xo-AV-r9d" firstAttribute="top" secondItem="dKe-mY-Q8g" secondAttribute="bottom" constant="14" id="cxa-w5-zHt"/>
                 <constraint firstItem="K3Q-df-0o3" firstAttribute="trailing" secondItem="6QB-Sz-gYR" secondAttribute="trailing" id="fw3-r6-EOz"/>
                 <constraint firstItem="YCL-cX-bWo" firstAttribute="leading" secondItem="CHj-7i-3Ej" secondAttribute="trailing" constant="8" symbolic="YES" id="jJN-vH-1KW"/>
+                <constraint firstItem="O7D-qa-qEI" firstAttribute="top" secondItem="CHj-7i-3Ej" secondAttribute="bottom" constant="25" id="kqE-Nt-qth"/>
                 <constraint firstItem="K3Q-df-0o3" firstAttribute="centerY" secondItem="q5O-D3-mgT" secondAttribute="centerY" id="mYj-NO-QFZ"/>
                 <constraint firstItem="Dkf-TQ-yQo" firstAttribute="leading" secondItem="q5O-D3-mgT" secondAttribute="leading" id="nqg-E8-90a"/>
                 <constraint firstItem="O7D-qa-qEI" firstAttribute="centerY" secondItem="dKe-mY-Q8g" secondAttribute="centerY" id="p8G-Ef-ywH"/>
                 <constraint firstItem="q5O-D3-mgT" firstAttribute="leading" secondItem="K3Q-df-0o3" secondAttribute="trailing" constant="8" symbolic="YES" id="q7k-pg-7vB"/>
+                <constraint firstItem="CHj-7i-3Ej" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6sE-tW-1JD" secondAttribute="leading" constant="20" symbolic="YES" id="qaZ-cr-EDb"/>
                 <constraint firstItem="6QB-Sz-gYR" firstAttribute="leading" secondItem="6sE-tW-1JD" secondAttribute="leading" constant="80" id="shD-zz-qgK"/>
+                <constraint firstItem="CHj-7i-3Ej" firstAttribute="top" secondItem="K3Q-df-0o3" secondAttribute="bottom" constant="50" id="zJw-il-hQG"/>
             </constraints>
             <point key="canvasLocation" x="233" y="161.5"/>
         </customView>
     </objects>
     <resources>
         <image name="VPNStatusItemOnImage" width="18" height="18"/>
-        <image name="network.badge.shield.half.filled" catalog="system" width="17" height="17"/>
+        <image name="network.badge.shield.half.filled" catalog="system" width="16" height="16"/>
     </resources>
 </document>

--- a/VPNStatus/PreferencesUI/ACPreferencesGeneralViewController.m
+++ b/VPNStatus/PreferencesUI/ACPreferencesGeneralViewController.m
@@ -48,15 +48,15 @@
 		[self.automaticCheckForUpdatesButton setState:NSControlStateValueOn];
 	}
 
-  BOOL singleAutoConnect = [[ACPreferences sharedPreferences] singleAutoConnect];
-  if(singleAutoConnect)
-  {
-    [self.singleAutoConnectButton setState:NSControlStateValueOn];
-  }
-  else
-  {
-    [self.singleAutoConnectButton setState:NSControlStateValueOff];
-  }
+	BOOL singleAutoConnect = [[ACPreferences sharedPreferences] singleAutoConnect];
+	if(singleAutoConnect)
+	{
+		[self.singleAutoConnectButton setState:NSControlStateValueOn];
+	}
+	else
+	{
+		[self.singleAutoConnectButton setState:NSControlStateValueOff];
+	}
 
 	NSMenu *theMenu = self.menuBarImagePopUpButton.menu;
 	for(NSInteger menuItemIndex = 0 ; menuItemIndex < theMenu.numberOfItems ; menuItemIndex++)
@@ -107,8 +107,8 @@
 
 - (IBAction)doSingleAutoConnect:(id)sender
 {
-  NSButton *checkbox = (NSButton *)sender;
-  [[ACPreferences sharedPreferences] setSingleAutoConnect:(checkbox.state != NSControlStateValueOff)];
+	NSButton *checkbox = (NSButton *)sender;
+	[[ACPreferences sharedPreferences] setSingleAutoConnect:(checkbox.state != NSControlStateValueOff)];
 }
 
 - (IBAction)doChangeMenuBarImage:(id)sender

--- a/VPNStatus/PreferencesUI/ACPreferencesGeneralViewController.m
+++ b/VPNStatus/PreferencesUI/ACPreferencesGeneralViewController.m
@@ -13,6 +13,7 @@
 
 @property (weak) IBOutlet NSTextField *retryDelayField;
 @property (weak) IBOutlet NSButton *automaticCheckForUpdatesButton;
+@property (weak) IBOutlet NSButton *singleAutoConnectButton;
 @property (weak) IBOutlet NSPopUpButton *menuBarImagePopUpButton;
 
 @end
@@ -46,6 +47,16 @@
 	{
 		[self.automaticCheckForUpdatesButton setState:NSControlStateValueOn];
 	}
+
+  BOOL singleAutoConnect = [[ACPreferences sharedPreferences] singleAutoConnect];
+  if(singleAutoConnect)
+  {
+    [self.singleAutoConnectButton setState:NSControlStateValueOn];
+  }
+  else
+  {
+    [self.singleAutoConnectButton setState:NSControlStateValueOff];
+  }
 
 	NSMenu *theMenu = self.menuBarImagePopUpButton.menu;
 	for(NSInteger menuItemIndex = 0 ; menuItemIndex < theMenu.numberOfItems ; menuItemIndex++)
@@ -92,6 +103,12 @@
 {
 	NSButton *checkbox = (NSButton *)sender;
 	[[ACPreferences sharedPreferences] setDisabledCheckForUpdatesAutomatically:(checkbox.state != NSControlStateValueOn)];
+}
+
+- (IBAction)doSingleAutoConnect:(id)sender
+{
+  NSButton *checkbox = (NSButton *)sender;
+  [[ACPreferences sharedPreferences] setSingleAutoConnect:(checkbox.state != NSControlStateValueOff)];
 }
 
 - (IBAction)doChangeMenuBarImage:(id)sender


### PR DESCRIPTION
Currently, when I choose "Always auto connect" for one service, it toggles auto-connect for that service.

I would like to have an option, so that when I activate auto-connect for one service, it deactivates auto-connect for all other services. In other words, only one service should be in use at a time.

The reason behind this, is an attempt to simplify usage of VPNStatus for people who want to simply choose between two options:

* Permanently connect to one service
* Turn it off

Instead of maintaining a fork of my own, I'm trying to support this upstream, in the hopes that it is useful for others.

I could add the setting to the preference pane and it successfully updates the preference file on disk. Even though it made a mess of the `xib` file and a constraint didn't quite work out:

<img width="595" alt="372810320-262b6b05-d2af-46ff-804e-46aca2a47c72" src="https://github.com/user-attachments/assets/3b577bd8-9601-415b-a07a-47f55b461bb3">

I wasn't sure, however, where to add the logic for deactivating `AlwaysConnected` of all other services. I've put it in the preference persistence logic now and unfortunately it doesn't seem to do anything. When I toggle the services in the menu bar, nothing happens in the preferences file. 

Do you have any thoughts on this? I'll keep on digging, but I thought I'd share it for now.

(PS: I'm planning on generally simplifying the menu bar entries later on with another pull request. I have so many VPN services in my menu, so that I actually have to scroll through the menu bar entries to see them all. I could imagine making the list of services a little more concise)

Thank you for your time. Since your last major code update, this app really improved a lot!