### PR TITLE
Inline "Auto Connect" menu item

### DIFF
--- a/VPNStatus/AppDelegate.m
+++ b/VPNStatus/AppDelegate.m
@@ -226,12 +226,7 @@
 				[menu addItem:[NSMenuItem separatorItem]];
 			}
 			
-			[menu addItem:[[NSMenuItem alloc] initWithTitle:neService.name action:nil keyEquivalent:@""]];
-			
-			// Update the information
-			[menu addItem:[[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:@"%@ (%@)", [neService serverAddress], [neService protocol]] action:nil keyEquivalent:@""]];
-			
-			NSMenuItem *alwaysAutoConnectMenuItem = [[NSMenuItem alloc] initWithTitle:@"Always auto connect" action:@selector(alwaysAutoConnect:) keyEquivalent:@""];
+			NSMenuItem *alwaysAutoConnectMenuItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:@"Always Connect %@", neService.name] action:@selector(alwaysAutoConnect:) keyEquivalent:@""];
 			[alwaysAutoConnectMenuItem setTag:neServiceIndex];
 			NSArray<NSString *>*alwaysConnectedServices = [[ACPreferences sharedPreferences] alwaysConnectedServicesIdentifiers];
 			if([alwaysConnectedServices containsObject:[neService.configuration.identifier UUIDString]])
@@ -244,6 +239,10 @@
 			}
 			
 			[menu addItem:alwaysAutoConnectMenuItem];
+			
+			// Update the information
+			[menu addItem:[[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:@"%@ (%@)", [neService serverAddress], [neService protocol]] action:nil keyEquivalent:@""]];
+
 			neServiceIndex++;
 		}
 		


### PR DESCRIPTION
Hi! 

In order to make the menu a little bit more concise, I thought I'd turn these three lines per service:

<img width="436" alt="before" src="https://github.com/user-attachments/assets/c7e456e5-3986-4cdb-8022-39c1a45e195e">

Into just two per service:

<img width="444" alt="after" src="https://github.com/user-attachments/assets/a777bbfa-91d9-4704-941d-6894a181fbeb">

This is also more consistent with the menu items above that have the format "Connect New York".

(I also think the domain name information could be improved, but I'm not sure yet how. It's only shown for the "Always Connect" menu items below but not for the "Connect" menu items above. Maybe it could be removed altogether or always shown, but that would be for another pull request.)

As for the capitalization of words, I tried to interpret the [Apple Guidelines](https://developer.apple.com/design/human-interface-guidelines/menus) to the best of my abilities and by comparing it to other apps.

As always, thank you for your time! I tried to get the tab indentation right this time :)
